### PR TITLE
Add scaffolding docs for future agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Multi-Agent Operating Guide
+
+## Roles and Responsibilities
+
+### Planner
+- **Focus**: Establish implementation strategy for features and documentation updates.
+- **Primary files**: `PLAN.md`, `TODO`, top-level docs under `docs/`.
+- **Hand-off**: Deliver a written plan highlighting scope, risks, and sequencing before coding begins; share explicit TODOs for the Implementer and Data Curator.
+
+### Ruby Implementer
+- **Focus**: Modify Ruby source under `lib/` and scripts in `bin/` to realize planned gameplay changes.
+- **Primary files**: `lib/*.rb`, `bin/game_player.rb`, supporting test files under `tests/`.
+- **Hand-off**: Provide diffs with inline notes for QA, summarize behavior changes, and flag any new data dependencies for the Data Curator.
+
+### Data Curator
+- **Focus**: Maintain YAML content and ensure game data aligns with engine expectations.
+- **Primary files**: `data/epic_adventure/*.yml`, future inventory/state configuration files.
+- **Hand-off**: Validate YAML integrity, document schema adjustments, and notify the Implementer/QA about new items or room states that require code/test coverage.
+
+### QA / Test Runner
+- **Focus**: Verify automated tests and perform smoke checks of the interactive game loop.
+- **Primary files**: `tests/*.rb`, execution scripts (`play.sh`).
+- **Hand-off**: Report test results with command outputs, capture observed regressions, and confirm that updated documentation remains accurate.
+
+## Shared Workflow Checklist
+1. **Discover & Align**
+   - Review `PROMPT.md`, `PLAN.md`, and relevant files.
+   - Inspect Ruby sources under `lib/` and YAML in `data/epic_adventure/`.
+2. **Implement**
+   - Follow the Planner's breakdown.
+   - Update Ruby or YAML files according to role-specific duties.
+3. **Test**
+   - Run unit tests with `rake test`.
+   - Perform a manual smoke test via `ruby play.sh` (terminates with `exit` or `quit`).
+4. **Review & Document**
+   - Cross-check changes against documentation and TODO items.
+   - Ensure commits reference impacted subsystems and data updates.
+
+## Known Constraints & Forward-Looking Requirements
+- Source files are ASCII; maintain encoding and avoid binary assets.
+- Game state depends heavily on YAML-defined rooms, messages, and items.
+- The command parser only understands `go <direction>`, `look`, `help`, `exit`, and `quit`.
+- The engine REPL loops indefinitely; always provide an exit path when testing.
+- `data/epic_adventure/items.yml` is present but unused—future work must introduce an inventory system that loads and manipulates these items.
+- Room descriptions remain static; upcoming features must support room state persistence so descriptions or available actions change after interactions.
+- The `TODO` file captures roadmap ideas (inventory, grammar improvements, NPCs, level editor); reference it when planning incremental deliveries.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,84 @@
+# Architecture Overview
+
+The text adventure is a lightweight Ruby application that wires together a bootstrapper, a simple REPL engine, and data-driven rooms. The entry point `bin/game_player.rb` instantiates `Bootstrap`, which loads YAML data, builds an `InputController`, and hands everything to `Game`. `Game` wraps an `Engine` responsible for printing messages, reading commands through `Readline`, and delegating them to the controller.
+
+## Component Map
+
+The following diagram shows the runtime components and the planned extension points for inventory and room state tracking. The Mermaid source lives at [`docs/diagrams/component_map.mmd`](diagrams/component_map.mmd).
+
+```mermaid
+graph TD
+    A[bin/game_player.rb] --> B[Bootstrap]
+    B -->|builds controller| C[Game]
+    C -->|starts| D[Engine]
+    D -->|delegates input| E[InputController]
+    E -->|moves avatar| F[Avatar]
+    F -->|occupies| G[Room]
+    B -->|loads| H[(locations.yml)]
+    B -->|loads| I[(messages.yml)]
+    H --> G
+    I --> E
+    E -->|future: manage| J[[Inventory System]]
+    J -->|consumes| K[(items.yml)]
+    G -->|future: persist| L[[Room State Tracker]]
+    L --> G
+```
+
+## Command Evaluation Sequence
+
+A `go north` command travels from the player's input to avatar movement through the components below. The Mermaid source is stored at [`docs/diagrams/command_sequence.mmd`](diagrams/command_sequence.mmd).
+
+```mermaid
+sequenceDiagram
+    participant P as Player
+    participant R as Readline
+    participant E as Engine
+    participant C as InputController
+    participant A as Avatar
+    participant RM as Room
+
+    P->>R: type "go north"
+    R->>E: returns input string
+    E->>C: evaluate("go north")
+    C->>C: validate tokens
+    alt invalid command
+        C->>E: set error message
+    else direction allowed
+        C->>A: can_move?("north")
+        alt room exists
+            A->>A: move to adjacent room
+            A->>RM: update current room reference
+            C->>E: update message with new description
+            Note over C,A: future inventory hooks adjust items
+            Note over RM: future room state changes descriptions
+        else blocked path
+            C->>E: message "cannot go north"
+        end
+    end
+    E->>P: print current message
+```
+
+## Data Loading and Relationships
+
+`Bootstrap` initializes a `GameDataLoader` to parse YAML files. `load_location_data` materializes `Room` instances, and `establish_relationships` replaces directional handles with room objects so the avatar can navigate. Messages such as the splash screen and contextual help come from `messages.yml` and are assigned to the controller. Although `items.yml` defines an item list, no runtime code currently loads it.
+
+Each room YAML entry may include:
+
+- `handle`: unique identifier used for directional links.
+- `desc`: base description shown when entering a room.
+- `info`: detailed description surfaced via `look`.
+- `rooms`: map of direction keywords to neighboring handles.
+- Optional `items`: currently unused by the engine.
+
+## Current Limitations and Planned Extensions
+
+- The `InputController` only recognizes `go`, `look`, `help`, `exit`, and `quit`, with minimal validation.
+- There is no inventory system: `items.yml` is never loaded, and rooms cannot give or remove items.
+- Room descriptions never change after actions, so collecting an item or revisiting a location shows identical text.
+- The REPL loop has no natural termination aside from `exit`/`quit`, so debugging requires manual intervention.
+
+Future work should incorporate:
+
+- An inventory subsystem that reads `items.yml`, associates items with rooms, enables pickup/use verbs, and updates the controller's responses.
+- A room state tracker that adjusts descriptions or available exits based on interactions.
+- Enhanced command parsing to support richer grammar, possibly leveraging the backlog noted in `TODO` (e.g., NPCs, level editor).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,35 @@
+# Development Guide
+
+## Environment Setup
+- Ensure Ruby is installed (MRI 2.6+ works with the current codebase).
+- Bundler is optional; dependencies are limited to the Ruby standard library (`yaml`, `readline`).
+- No linting tooling is configured.
+
+## Running Tests and Checks
+- Execute automated tests with `rake test`.
+- Perform an interactive smoke test with `ruby play.sh` and exit via `quit` or `exit`.
+
+## Project Structure
+- `bin/game_player.rb`: CLI entry point that starts the adventure.
+- `lib/`: Ruby classes (`Bootstrap`, `Game`, `Engine`, `InputController`, `Avatar`, `Room`, `GameDataLoader`).
+- `data/epic_adventure/`: YAML data for rooms (`locations.yml`), player messaging (`messages.yml`), and items (`items.yml`).
+- `tests/`: MiniTest coverage for core classes.
+- `TODO`: Roadmap for upcoming features (inventory, parser improvements, NPCs, editor).
+
+## Data Management
+- `locations.yml` contains an array of rooms, each with `handle`, `desc`, `info`, directional `rooms`, and optional `items` fields.
+- `messages.yml` holds simple key/value pairs for splash/help text.
+- `items.yml` defines items with `handle`, `name`, and `description`, ready for future inventory integration.
+- When adding rooms or items:
+  - Maintain unique `handle` values so `GameDataLoader` can resolve connections.
+  - Keep descriptions concise and ASCII-only.
+  - Mirror new item handles inside room definitions where items should appear.
+  - Document schema changes in `AGENTS.md` for the Data Curator.
+- Plan for inventory state by associating items with rooms and, eventually, with the avatar.
+- Anticipate room state persistence by tracking flags (e.g., `item_taken`) once the feature exists.
+
+## Working Agreements
+- Favor simple, expressive Ruby with clear method responsibilities.
+- Use MiniTest for unit coverage; add tests alongside new behaviors.
+- Validate inventory and room state changes with focused tests that assert message updates and avatar state transitions.
+- Update documentation (`docs/architecture.md`, `docs/development.md`) when introducing new subsystems or data formats.

--- a/docs/diagrams/command_sequence.mmd
+++ b/docs/diagrams/command_sequence.mmd
@@ -1,0 +1,27 @@
+sequenceDiagram
+    participant P as Player
+    participant R as Readline
+    participant E as Engine
+    participant C as InputController
+    participant A as Avatar
+    participant RM as Room
+
+    P->>R: type "go north"
+    R->>E: returns input string
+    E->>C: evaluate("go north")
+    C->>C: validate tokens
+    alt invalid command
+        C->>E: set error message
+    else direction allowed
+        C->>A: can_move?("north")
+        alt room exists
+            A->>A: move to adjacent room
+            A->>RM: update current room reference
+            C->>E: update message with new description
+            Note over C,A: future inventory hooks adjust items
+            Note over RM: future room state changes descriptions
+        else blocked path
+            C->>E: message "cannot go north"
+        end
+    end
+    E->>P: print current message

--- a/docs/diagrams/component_map.mmd
+++ b/docs/diagrams/component_map.mmd
@@ -1,0 +1,15 @@
+graph TD
+    A[bin/game_player.rb] --> B[Bootstrap]
+    B -->|builds controller| C[Game]
+    C -->|starts| D[Engine]
+    D -->|delegates input| E[InputController]
+    E -->|moves avatar| F[Avatar]
+    F -->|occupies| G[Room]
+    B -->|loads| H[(locations.yml)]
+    B -->|loads| I[(messages.yml)]
+    H --> G
+    I --> E
+    E -->|future: manage| J[[Inventory System]]
+    J -->|consumes| K[(items.yml)]
+    G -->|future: persist| L[[Room State Tracker]]
+    L --> G


### PR DESCRIPTION
## Summary
- add AGENTS.md detailing multi-agent workflow, roles, and constraints
- document architecture, command flow, and extension points in docs/architecture.md with supporting Mermaid diagrams
- provide development guide covering setup, testing commands, and data management expectations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d4081a508320a9f211ae678bf914